### PR TITLE
Generate a better summary.

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -38,6 +38,47 @@ module.exports = function (env) {
 
   ------------------------------------------------------------------ */
 
+  filters.generate_summary = function(dataset) {
+    const edit_date = Date.parse(dataset.last_edit_date)
+    const new_date = Date.parse("2017-04-01")
+    if (edit_date > new_date) {
+      return dataset.summary
+    }
+
+    const stop_punctuation = ['.', '!', '?', ',', '\n']
+    const start_idx = 160
+    const seek_idx = 30
+
+    if (dataset.notes.length <= start_idx ||
+        dataset.notes[start_idx] in stop_punctuation ) {
+      return dataset.notes
+    }
+
+    // Is there punctuation up to 30 chars before the pivot point?
+    for( var i = start_idx; i >= start_idx-seek_idx; i--) {
+      if ( stop_punctuation.indexOf(dataset.notes[i]) != -1) {
+        return dataset.notes.substring(0, i)
+      }
+    }
+
+    // Is there punctuation up to 30 chars after the pivot point
+    for( var i = start_idx; i <= start_idx+seek_idx; i++) {
+      if (stop_punctuation.indexOf(dataset.notes[i]) != -1) {
+        return dataset.notes.substring(0, i)
+      }
+    }
+
+    // Panic stations, is this description actually just a
+    // single sentence?
+    for( var i = start_idx; i >= 0; i--) {
+      if ( stop_punctuation.indexOf(dataset.notes[i]) != -1) {
+        return dataset.notes.substring(0, i)
+      }
+    }
+
+    return dataset.notes.substring(0, start_idx)
+  }
+
   filters.sortedByDisplay = function(option) {
     switch (option) {
       case 'recent':

--- a/app/views/datasets/dataset.html
+++ b/app/views/datasets/dataset.html
@@ -32,7 +32,7 @@
         <h3 class="heading-small">
             Summary
         </h3>
-        <p class="summary" style="max-height: 250px; overflow: hidden"> {{ result.notes }} </p>
+        <p class="summary" style="max-height: 250px; overflow: hidden"> {{ result | generate_summary }} </p>
       </div>
       <section class="data-links">
     </div>
@@ -88,6 +88,11 @@
         <h2 class="heading-medium">
           Additional information
         </h2>
+
+        <p class="additional-information">
+          {{ result.notes }}
+        </p>
+
         <p class="additional-information"> This dataset is available under the <a href="">Open Government Licence</a>. All the data variables are coded rather than
         containing textual strings. The look up tables are available under "Additional resources" section towards the border-bottom
         of the table for the 2015 data.

--- a/app/views/search-results.html
+++ b/app/views/search-results.html
@@ -59,7 +59,7 @@
                 <dd class="unavailable">Not available</dd>
               {% endif %}
             </dl>
-          <p>{{ dataset.summary | truncate(140)  }}</p>
+          <p>{{ dataset | generate_summary  }}</p>
         </div>
       </div>
       {% endfor %}


### PR DESCRIPTION
* Moves the dataset description to additional information

* Generates a better summary after checking the edit date. Anything
  edited after April will just use the summary. Anything else will
  attempt to trim down the summary to something more meaningfull based
  on the notes (description) field rather than the auto-generated
  summary from publish-data alpha which is a bit weak.

Fixes part of https://github.com/datagovuk/find-gov-data-v3/issues/37
and also https://github.com/datagovuk/find-gov-data-v3/issues/35