### PR TITLE
Add a date coverage column for data files

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -139,6 +139,11 @@ table th, table td {
   padding-right: 35px;
   padding-left: 0;
   vertical-align: top;
+  font-size: 16px;
+  white-space: nowrap;
+  &:last-child {
+    padding-right: 0;
+  }
 }
 
 table th.title, table td.title {

--- a/app/filters.js
+++ b/app/filters.js
@@ -109,6 +109,18 @@ module.exports = function (env) {
       }
     }
 
+  filters.calculate_date = function(resource, updated) {
+    if (updated == 'annually' && resource.start_date != '' ) {
+      return resource.start_date.substring(0, 4)
+    }
+
+    if (updated == 'daily') {
+      return 'Continuous'
+    }
+
+    return 'Not applicable'
+  }
+
 
   /* ------------------------------------------------------------------
     keep the following line to return your filters to the app

--- a/app/views/includes/datalinks/non_time_series.html
+++ b/app/views/includes/datalinks/non_time_series.html
@@ -4,6 +4,7 @@
   <table>
     <tr>
       <th class="title">Link to the data</th>
+      <th>Date coverage</th>
       <th>Format</th>
       <th>Last updated</th>
       <th>Data preview</th>
@@ -13,6 +14,9 @@
       <tr {% if result.resources.slice(5).includes(datafile) %} class='js-show-more-datafiles' {% endif %}>
         <td class="title"><a href="{{ datafile.url }}">
           {{ datafile.name or "Data Link"}}
+        </td>
+        <td>
+          {{ datafile | calculate_date }}
         </td>
         {% if datafile.format %}
         <td>{{ datafile.format }} (347kb)</td>

--- a/app/views/includes/datalinks/time_series.html
+++ b/app/views/includes/datalinks/time_series.html
@@ -15,7 +15,7 @@
       <table>
         <tr>
           <th class="title">Link to the data</th>
-          <th>Date coverage</th>
+          <th>Time period</th>
           <th>Format</th>
           <th>Last updated</th>
           <th>Data preview</th>

--- a/app/views/includes/datalinks/time_series.html
+++ b/app/views/includes/datalinks/time_series.html
@@ -29,9 +29,6 @@
                 {% endif %}
               </td>
               <td>
-                {{ datafile | calculate_date }}
-              </td>
-              <td>
                 {{ datafile | calculate_date(result.update_frequency) }}
               </td>
               {% if datafile.format %}

--- a/app/views/includes/datalinks/time_series.html
+++ b/app/views/includes/datalinks/time_series.html
@@ -15,6 +15,7 @@
       <table>
         <tr>
           <th class="title">Link to the data</th>
+          <th>Date coverage</th>
           <th>Format</th>
           <th>Last updated</th>
           <th>Data preview</th>
@@ -27,8 +28,14 @@
                 {% else %} Data Link
                 {% endif %}
               </td>
+              <td>
+                {{ datafile | calculate_date }}
+              </td>
+              <td>
+                {{ datafile | calculate_date(result.update_frequency) }}
+              </td>
               {% if datafile.format %}
-              <td>{{ datafile.format }} (347kb)</td>
+              <td>{{ datafile.format | upper }} (347kb)</td>
               {% else %}
               <td>N/A</td>
               {% endif %}


### PR DESCRIPTION
Currently if annual, will show the year that the link covers ...

If daily, will say Continuous (as it is always updating).

If anything else will say Not applicable.

Working on doing Quarters for the next PR, but have to find a dataset I can use :) 
Will likely format as   "Q1 2016"

Then will do monthly and will likely format as Jan 2017