### PR TITLE
Adds navigation breadcrumbs

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -241,6 +241,8 @@ function renderDataset(template, req, res, next) {
     }
   }
 
+  const backURL = req.header('Referer') || '/';
+
   esClient.search(esQuery, (esError, esResponse) => {
     var result = processEsResponse(esResponse)[0]
     const cmpStrings = (s1, s2) => s1 < s2 ? 1 : (s1 > s2 ? -1 : 0)
@@ -283,7 +285,8 @@ function renderDataset(template, req, res, next) {
           res.render(template, {
             result: result,
             related_datasets: matches,
-            groups: groupByDate(result)
+            groups: groupByDate(result),
+            back: backURL
           })
         })
      }

--- a/app/views/datasets/dataset.html
+++ b/app/views/datasets/dataset.html
@@ -8,6 +8,25 @@
 
 <main id="content" role="main">
   <div class="grid-row">
+
+    <div class="breadcrumbs">
+    	<ol role="breadcrumbs">
+    	  <li><a href="/">Home</a></li>
+        <!-- Checking if 'search-results' is in the referrer URL
+        to pick up whether or not the user has come from our search results page,
+        or from say google. Need to change when we know our URL -->
+        {% set regExp = r/.*search-results.*/gi %}
+        <li>
+          {% if regExp.test(back) %}
+          <a href="{{back}}">Search Results</a>
+        </li>
+          {% else %}
+          <a href="">{{ result.organisation.title }}</a>
+          {% endif %}
+    	  <li>{{ result.title }}</li>
+    	</ol>
+    </div>
+
     <div class="column-two-thirds">
 
       <h1 class="heading-large">

--- a/app/views/datasets/dataset.html
+++ b/app/views/datasets/dataset.html
@@ -12,10 +12,10 @@
     <div class="breadcrumbs">
     	<ol role="breadcrumbs">
     	  <li><a href="/">Home</a></li>
-        <!-- Checking if 'search-results' is in the referrer URL
-        to pick up whether or not the user has come from our search results page,
-        or from say google. Need to change when we know our URL -->
-        {% set regExp = r/.*search-results.*/gi %}
+          <!-- Checking if 'search-results' is in the referrer URL
+          to pick up whether or not the user has come from our search results page,
+          or from say google. Need to change when we know our URL -->
+          {% set regExp = r/.*search-results.*/gi %}
         <li>
           {% if regExp.test(back) %}
           <a href="{{back}}">Search Results</a>


### PR DESCRIPTION
as per @BlancaTortajada request:
- ### if the user lands on the dataset page from google, the referrer link is the publisher title.
<img width="603" alt="screen shot 2017-05-19 at 13 38 01" src="https://cloud.githubusercontent.com/assets/17908089/26248022/6f0949b2-3c98-11e7-8681-110682d84ec6.png">


- ###  if the user arrives at the dataset page from our search results page, the referrer link is Search Results

<img width="548" alt="screen shot 2017-05-19 at 13 04 33" src="https://cloud.githubusercontent.com/assets/17908089/26247996/52448f3a-3c98-11e7-9829-de6857829ef1.png">