### PR TITLE
Add real file sizes

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -38,6 +38,21 @@ module.exports = function (env) {
 
   ------------------------------------------------------------------ */
 
+  filters.get_link_size = function(datafile) {
+    if (datafile.format == 'HTML') return ''
+
+    if (datafile.size == 0) {
+      return ''
+    }
+
+    kb = Number((datafile.size / 1000).toFixed(1))
+    if ( kb > 1024 ) {
+      kb = Number((kb / 1000).toFixed(1))
+      return ' (' + kb + 'Mb)'
+    }
+    return ' (' + kb + 'Kb)'
+  }
+
   filters.generate_summary = function(dataset) {
     const edit_date = Date.parse(dataset.last_edit_date)
     const new_date = Date.parse("2017-04-01")

--- a/app/views/includes/datalinks/non_time_series.html
+++ b/app/views/includes/datalinks/non_time_series.html
@@ -15,7 +15,7 @@
           {{ datafile.name or "Data Link"}}
         </td>
         {% if datafile.format %}
-        <td>{{ datafile.format }} (347kb)</td>
+        <td>{{ datafile.format }} {{ datafile | get_link_size }}</td>
         {% else %}
         <td>N/A</td>
         {% endif %}

--- a/app/views/includes/datalinks/time_series.html
+++ b/app/views/includes/datalinks/time_series.html
@@ -28,7 +28,7 @@
                 {% endif %}
               </td>
               {% if datafile.format %}
-              <td>{{ datafile.format }} (347kb)</td>
+              <td>{{ datafile.format }} {{ datafile | get_link_size }} </td>
               {% else %}
               <td>N/A</td>
               {% endif %}


### PR DESCRIPTION
If we know the file size, we'll use it.
We don't display a size when:

a. We don't know it.
b. It's HTML