### PR TITLE
Remove non-word chars, or app will crash

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -137,7 +137,7 @@ router.get('/search-results', function(req, res, next) {
     body: {
       query: {
         query_string: {
-          query: query_string,
+          query: query_string.replace(/\W/g, ''),
           fields: [
                    "summary^2", "title^3", "description^1",
                    "location1^2", "location2^2", "location3^2",
@@ -205,7 +205,7 @@ const get_more_like_this = (dataset, n) => {
       query: {
         more_like_this: {
           fields : ["title^3", "summary^3", "notes", "organisation_name^2"],
-          like : like,
+          like : like.replace(/\W/g, ''),
           min_term_freq : 4,
           max_query_terms : 12
         }


### PR DESCRIPTION
ES doesn't like / in search terms.
There are options to make it ignore them, but don't seem to be working in our queries, 
so we just filter out the bad characters in the query
