### PR TITLE
Make sure Most Recent is an option with no search terms

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -123,7 +123,7 @@ router.get('/search-results', function(req, res, next) {
   // relevance against. At the same time, we want to match everything if the
   // user has provided no terms so we will search for *
   if (query_string == ""){
-    sortBy = 'recent'
+    if (!sortBy) sortBy = 'recent'
     query_string = "*"
   }
 


### PR DESCRIPTION
Was previously forcing the sort order when there was no search terms.
Now only chooses 'recent' for empty search when there is no other value.

Fixes #26