### PR TITLE
#27 Change focus style for header links

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -38,6 +38,15 @@ $path: "/public/images/";
   background: none;
 }
 
+// Fix header link focus for accessibility
+#global-header a:focus {
+  color: #fff !important;
+  text-decoration: underline !important;
+
+  // Added !important as a hack to force a elements in #proposition links
+  // to use the correct behaviour
+}
+
 #global-header-bar {
   display: none;
 }


### PR DESCRIPTION
See issue #27. Adds a couple CSS rules that keep focused header elements visible, and highlights them with an underline.