### PR TITLE
On preview pages, make side background white not grey

### DIFF
--- a/app/views/preview-1.html
+++ b/app/views/preview-1.html
@@ -6,6 +6,11 @@
 
 {% block content %}
 
+
+<style>
+ html { background: white }
+</style>
+
 <main class="preview" id="content" role="main">
   <div class="grid-row">
     <div class="column-full">


### PR DESCRIPTION
so that background remains white as page is scrolled vertically
to pan across the table. Header and footer should extend too,
but that's too complicated for this prototype